### PR TITLE
Fix worker not starting after plugin reload (mac)

### DIFF
--- a/src/xplane.c
+++ b/src/xplane.c
@@ -247,7 +247,7 @@ sim_intf_init(void)
 	avl_create(&acf_pos_tree, acf_pos_compar, sizeof (acf_pos_t),
 	    offsetof(acf_pos_t, tree_node));
 	mutex_init(&acf_pos_lock);
-
+	custom_bus = B_FALSE;
 	intf_inited = B_TRUE;
 }
 

--- a/src/xtcas.c
+++ b/src/xtcas.c
@@ -2602,6 +2602,7 @@ xtcas_init(const sim_intf_input_ops_t *intf_input_ops,
 	dbg_log(tcas, 1, "init");
 
 	inited = B_TRUE;
+    worker_shutdown = B_FALSE;
 
 	ASSERT(intf_input_ops != NULL);
 	ASSERT(intf_input_ops->get_time != NULL);

--- a/src/xtcas.c
+++ b/src/xtcas.c
@@ -2602,7 +2602,7 @@ xtcas_init(const sim_intf_input_ops_t *intf_input_ops,
 	dbg_log(tcas, 1, "init");
 
 	inited = B_TRUE;
-    worker_shutdown = B_FALSE;
+	worker_shutdown = B_FALSE;
 
 	ASSERT(intf_input_ops != NULL);
 	ASSERT(intf_input_ops->get_time != NULL);


### PR DESCRIPTION
- On macOS, it seems like global storage isn’t re-initialised when plugins are reloaded, leading to worker_shutdown staying true, and the worker thread exiting immediately. Initialised the variable to false in xtcas_init() to prevent this.